### PR TITLE
Add "Update" Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ Feel free to update the list from [university-domains-list](https://github.com/h
     }
     ]
 
+## API Update Endpoint
+If the university dataset changes, the API won't automatically update it. Use this endpoint to force a refresh.
+
+### Request
+    /update
+
+### Response
+    {
+        'status': str,
+        'message': str
+    }
 
 ## Run the Project
 


### PR DESCRIPTION
This PR implements #7 

- Adds "/update" as an endpoint that calls load_data to refresh the university dataset. The API only allows a single refresh every hour (based on UPDATE_WAIT_TIME).

- Update README